### PR TITLE
HAI-2342: Producing tormays_cycle_infra_polys

### DIFF
--- a/README.md
+++ b/README.md
@@ -304,14 +304,15 @@ Output files (names configured in `config.yaml`)
 
 ### `cycle_infra`
 
-Prerequisite: copy source file to `data` -directory. See `data/README.md`
+Prerequisite: fetched `ylre_katualueet` and `cycle_infra` -materials.
 
 Docker example run (ensure that image build and file copying is
 already performed as instructed above):
 
 ```sh
 docker-compose up -d gis-db
-docker-compose run --rm gis-fetch cycle_infra
+docker-compose run --rm gis-fetch ylre_katualueet cycle_infra
+docker-compose run --rm gis-process ylre_katualueet
 docker-compose run --rm gis-process cycle_infra
 docker-compose stop gis-db
 ```
@@ -347,7 +348,7 @@ Output files (names configured in `config.yaml`)
 
 ### `liikennevaylat`
 
-Prerequisite: 
+Prerequisite:
 - `central_business_area` material fetched
 - `ylre_katuosat` material fetched
 - `liikennevaylat` material fetched
@@ -389,9 +390,9 @@ Where `<source>` is currently one of:
 - `ylre_katualueet` - Helsinki YLRE street areas, polygons.
 - `ylre_katuosat` - Helsinki YLRE parts, polygons.
 - `maka_autoliikennemaarat` - Traffic volumes (car traffic)
-- `tram_infra` - Tram infra  
+- `tram_infra` - Tram infra
 - `tram_lines` - Tram railways
-- `cycle_infra` - Cycle infra (local file)
+- `cycle_infra` - Helsinki city cycle infra
 - `central_business_area` - Helsinki city "kantakaupunki"
 - `liikennevaylat` - Helsinki city street classes
 
@@ -416,7 +417,7 @@ All sources are having own configuration variables in config.yaml. These are inc
   validate_limit_max: 1.10
 ```
 
-where 
+where
 - `tormays_table_org` = "tormays" table name which is used in Haitaton (variable is used in gis-process)
 - `tormays_table_temp` = temporary table name where gis-process will save processed data (variable is used in gis-process)
 - `validate_limit_min` = percentage lower limit on "tormays" data eg. 0.98: (line amount of "tormays_table_org")*0.98 (variable is used in gis-validate-deploy)
@@ -426,10 +427,10 @@ where
 
 Total automation process includes this processes:
 - gis-fetch (Remark: each source is having it's own prerequisites)
-- gis-process (Remark: tormays_table_org value should be equivalent to Haitaton model) 
+- gis-process (Remark: tormays_table_org value should be equivalent to Haitaton model)
 - gis-validate-deploy (Remark: validate_limit_min and validate_limit_max values)
 
-Automation of  the `<source>`: 
+Automation of  the `<source>`:
 
 ```sh
 docker-compose run --rm gis-fetch <source>

--- a/automation/README.md
+++ b/automation/README.md
@@ -44,10 +44,8 @@ Where `<source>` is currently one of:
 - `ylre_katualueet` - Helsinki YLRE street areas, polygons.
 - `ylre_katuosat` - Helsinki YLRE parts, polygons.
 - `maka_autoliikennemaarat` - Traffic volumes (car traffic)
-- ~~`cycle_infra` - Cycle infra (local file)~~
+- `cycle_infra` - Cycle infra (local file)
 - `central_business_area` - Helsinki city "kantakaupunki"
 - `liikennevaylat` - Helsinki city street classes
-
-Source `cycle_infra` is not yet supported because it is using static local files.
 
 This docker image run will fetch `<source>` data, process it and after that `<source>` data will be validated and deployed to the database using given environment variables.

--- a/automation/README.md
+++ b/automation/README.md
@@ -44,7 +44,7 @@ Where `<source>` is currently one of:
 - `ylre_katualueet` - Helsinki YLRE street areas, polygons.
 - `ylre_katuosat` - Helsinki YLRE parts, polygons.
 - `maka_autoliikennemaarat` - Traffic volumes (car traffic)
-- `cycle_infra` - Cycle infra (local file)
+- `cycle_infra` - Helsinki city cycle infra
 - `central_business_area` - Helsinki city "kantakaupunki"
 - `liikennevaylat` - Helsinki city street classes
 

--- a/automation/automation.sh
+++ b/automation/automation.sh
@@ -17,6 +17,9 @@ do
     liikennevaylat)
         sources="${sources} liikennevaylat central_business_area ylre_katuosat"
         ;;
+    cycle_infra)
+        sources="${sources} cycle_infra ylre_katualueet"
+        ;;
     *)
         sources="${sources} $tormays_source"
         ;;
@@ -39,6 +42,9 @@ else
         case $tormays_source in
         liikennevaylat)
             /opt/venv/bin/python /haitaton-gis/process_data.py central_business_area ylre_katuosat $tormays_source
+            ;;
+        cycle_infra)
+            /opt/venv/bin/python /haitaton-gis/process_data.py ylre_katualueet $tormays_source
             ;;
         *)
             /opt/venv/bin/python /haitaton-gis/process_data.py $tormays_source

--- a/config.yaml
+++ b/config.yaml
@@ -94,7 +94,7 @@ cycle_infra:
   target_buffer_file: "tormays_cycle_infra_polys.gpkg"
   tormays_table_org: "tormays_cycle_infra_polys"
   validate_limit_min: 0.40
-  validate_limit_max: 1.10
+  validate_limit_max: 1.50
   buffer_class_values:
     kaista: 1
     yksisuuntainen: 1.5

--- a/config.yaml
+++ b/config.yaml
@@ -93,7 +93,7 @@ cycle_infra:
   target_file: "cycle_infra.gpkg"
   target_buffer_file: "tormays_cycle_infra_polys.gpkg"
   tormays_table_org: "tormays_cycle_infra_polys"
-  validate_limit_min: 0.98
+  validate_limit_min: 0.40
   validate_limit_max: 1.10
   buffer_class_values:
     kaista: 1
@@ -104,6 +104,7 @@ cycle_infra:
     - 20
 #  store_orinal_data: False
   store_orinal_data: "cycle_infra_test"
+  ylre_street_class_buffer: 10
 liikennevaylat:
   addr: "WFS:https://$HELSINKI_EXTRANET_USERNAME:$HELSINKI_EXTRANET_PASSWORD@kartta.hel.fi/ws/geoserver/helsinki/wfs"
   layer: "helsinki:Liikennevaylat_kehitys"

--- a/config.yaml
+++ b/config.yaml
@@ -71,6 +71,7 @@ tram_infra:
   validate_limit_min: 0.98
   validate_limit_max: 1.10
   buffer:
+    - 4
     - 20
   store_orinal_data: False
 #  store_orinal_data: "tram_infra"
@@ -86,17 +87,23 @@ tram_lines:
   store_orinal_data: False
 #  store_orinal_data: "tram_lines"
 cycle_infra:
-  addr: "/local_data/helsinki_cycleways.gpkg"
+  addr: "WFS:https://$HELSINKI_EXTRANET_USERNAME:$HELSINKI_EXTRANET_PASSWORD@kartta.hel.fi/ws/geoserver/helsinki/wfs"
+  layer: "helsinki:Liikennevaylat_kehitys"
   local_file: "helsinki_cycleways.gpkg"
   target_file: "cycle_infra.gpkg"
   target_buffer_file: "tormays_cycle_infra_polys.gpkg"
   tormays_table_org: "tormays_cycle_infra_polys"
   validate_limit_min: 0.98
   validate_limit_max: 1.10
+  buffer_class_values:
+    kaista: 1
+    yksisuuntainen: 1.5
+    kaksisuuntainen: 2
+    kaksisuuntainen_baana: 2.5
   buffer:
     - 20
-  store_orinal_data: False
-#  store_orinal_data: "cycle_infra"
+#  store_orinal_data: False
+  store_orinal_data: "cycle_infra_test"
 liikennevaylat:
   addr: "WFS:https://$HELSINKI_EXTRANET_USERNAME:$HELSINKI_EXTRANET_PASSWORD@kartta.hel.fi/ws/geoserver/helsinki/wfs"
   layer: "helsinki:Liikennevaylat_kehitys"
@@ -165,10 +172,10 @@ local_docker_development:
 docker_development:
   database:
     port: 154321
-    host: localhost1
-    username: haitaton1
-    password: haitaton1
-    database: haitaton1
+    host: localhost
+    username: haitaton
+    password: haitaton
+    database: haitaton
   storage:
     download_dir: "/downloads"
     output_dir: "/gis-output"

--- a/fetch/fetch_data.sh
+++ b/fetch/fetch_data.sh
@@ -64,10 +64,6 @@ case $data_object in
 hsl)
     wget -O "$local_file" "$addr"
     ;;
-# plain cp from local file system
-cycle_infra_old)
-    cp "$addr" "$local_file"
-    ;;
 # plain WFS fetch
 hki|ylre_katualueet|ylre_katuosat|maka_autoliikennemaarat|osm|helsinki_osm_lines|central_business_area)
     ogr2ogr -progress -f GPKG "$local_file" ${extra_args:+$extra_args} ${extra_quoted_args:+"$extra_quoted_args"} "$addr" "$layer"

--- a/fetch/fetch_data.sh
+++ b/fetch/fetch_data.sh
@@ -65,7 +65,7 @@ hsl)
     wget -O "$local_file" "$addr"
     ;;
 # plain cp from local file system
-cycle_infra)
+cycle_infra_old)
     cp "$addr" "$local_file"
     ;;
 # plain WFS fetch
@@ -73,7 +73,7 @@ hki|ylre_katualueet|ylre_katuosat|maka_autoliikennemaarat|osm|helsinki_osm_lines
     ogr2ogr -progress -f GPKG "$local_file" ${extra_args:+$extra_args} ${extra_quoted_args:+"$extra_quoted_args"} "$addr" "$layer"
     ;;
 # plain WFS fetch with authentication
-liikennevaylat)
+liikennevaylat|cycle_infra)
     addr_with_authentication=$(echo $addr | sed -E 's/\$\$([A-Z]+)\$\$/${\1}/g' | envsubst)
     ogr2ogr -progress -f GPKG "$local_file" ${extra_args:+$extra_args} ${extra_quoted_args:+"$extra_quoted_args"} "$addr_with_authentication" "$layer"
     ;;

--- a/process/modules/config.py
+++ b/process/modules/config.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 from os.path import exists
 from pathlib import Path
 import yaml
+import os
 
 
 class Config:
@@ -111,6 +112,10 @@ class Config:
         """Return buffer value list from configuration."""
         return self._cfg.get(item, {}).get("buffer_class_values")
 
+    def ylre_street_class_buffer(self, item: str) -> str:
+        """Return buffer value list from configuration."""
+        return self._cfg.get(item, {}).get("ylre_street_class_buffer")
+
     def pg_conn_uri(self, deployment: str = None) -> str:
         """Return PostgreSQL connection URI
 
@@ -119,9 +124,9 @@ class Config:
             deployment = self.deployment_profile()
 
         return "postgresql://{user}:{password}@{host}:{port}/{dbname}".format(
-            user=self._cfg.get(deployment, {}).get("database").get("username"),
-            password=self._cfg.get(deployment, {}).get("database").get("password"),
-            host=self._cfg.get(deployment, {}).get("database").get("host"),
-            port=self._cfg.get(deployment, {}).get("database").get("port"),
-            dbname=self._cfg.get(deployment, {}).get("database").get("database"),
+            user=os.environ.get("HAITATON_USER",self._cfg.get(deployment, {}).get("database").get("username")),
+            password=os.environ.get("HAITATON_PASSWORD",self._cfg.get(deployment, {}).get("database").get("password")),
+            host=os.environ.get("HAITATON_HOST",self._cfg.get(deployment, {}).get("database").get("host")),
+            port=os.environ.get("HAITATON_PORT",self._cfg.get(deployment, {}).get("database").get("port")),
+            dbname=os.environ.get("HAITATON_DATABASE",self._cfg.get(deployment, {}).get("database").get("database")),
         )

--- a/process/modules/cycling_infra.py
+++ b/process/modules/cycling_infra.py
@@ -2,9 +2,16 @@ import geopandas as gpd
 import pandas as pd
 import numpy as np
 from sqlalchemy import create_engine, text
+#from shapely.validation import explain_validity
+from os import path
+from shapely.validation import make_valid
+from shapely.geometry import MultiPolygon, Polygon, GeometryCollection
 
 from modules.config import Config
 from modules.gis_processing import GisProcessor
+
+import warnings
+warnings.simplefilter(action='ignore', category=FutureWarning)
 
 
 class CycleInfra(GisProcessor):
@@ -19,6 +26,17 @@ class CycleInfra(GisProcessor):
 
         file_name = cfg.local_file(self._module)
         self._store_original_data = cfg.store_orinal_data(self._module)
+        self._ylre_street_class_buffer = cfg.ylre_street_class_buffer(self._module)
+
+        # check that ylre_katualueet file is available
+        if not path.exists(self._cfg.target_buffer_file("ylre_katualueet")):
+            raise FileNotFoundError("ylre katualueet polygon not found")
+
+        # Loading ylre_katualueet dataset
+        ylre_katualueet_filename = cfg.target_buffer_file("ylre_katualueet")
+        self._ylre_katualueet = gpd.read_file(ylre_katualueet_filename)
+        self._ylre_katualueet["geometry"] = self._ylre_katualueet.buffer(self._ylre_street_class_buffer)
+        self._ylre_katualueet_sindex = self._ylre_katualueet.sindex
 
         # Following hierarchy levels included into data
         self._hierarkia = [
@@ -26,27 +44,6 @@ class CycleInfra(GisProcessor):
             "Muu pyöräreitti",
             "Baana",
             "Pääpyöräreitti",
-        ]
-
-        # Following alatyyppi values included into data
-        self._alatyyppi = [
-            "Yhdistetty jalkakäytävä ja pyörätie",
-            #"Jalkakäytävä",
-            "Pyöräkatu",
-            "Pyörätie",
-            "Välikaistalla eroteltu pyörätie",
-            #"Muu polku",
-            "Pyöräkaista",
-            #"Ulkoilureitti",
-            "Tasoeroteltu pyörätie",
-            "Pyöräliikenteen ylityspaikka",
-            #"Kulkuväylä aukiolla",
-            "Jalkakäytävä ja pyörätie samassa tasossa",
-            "Jalkakäytävän tasossa oleva pyörätie",
-            "Puistotie- tai väylä",
-            "Piha- ja/tai kävelykatu",
-            "Välikaistalla erotellut jalkakäytävä ja pyörätie",
-            #"Suojatie",
         ]
 
         # Following main and sub type combinations can be removed from data
@@ -132,6 +129,7 @@ class CycleInfra(GisProcessor):
             "id",
             "uuid",
             "hierarkia_yksisuuntaisuus",
+            "index_right0",
         ]
 
         self._lines = gpd.read_file(file_name)
@@ -180,21 +178,39 @@ class CycleInfra(GisProcessor):
 
         return retval
 
+    def _check_and_set_ylre_classes_id(self, lines: gpd.GeoDataFrame) -> gpd.GeoDataFrame:
+        attrs = ["ylre_class", "kadun_nimi"]
+        ylre_katualueet_dissolved = self._ylre_katualueet.dissolve(by=attrs)
+        joined_result = gpd.sjoin(lines, ylre_katualueet_dissolved, predicate='within')
+
+        retval = lines.merge(joined_result[['uuid', 'index_right0', 'index_right1']], how='left', left_on='uuid', right_on='uuid')
+
+        return retval
+
+    def _makeValid(self, data, geom_column):
+        data[geom_column] = data.apply(lambda row: make_valid(row[geom_column]) if not row[geom_column].is_valid else row[geom_column], axis=1)
+        return(data)
+
     def process(self):
         self._process_result_lines = self._lines
 
         # Drop unnecessary data rows base on main and sub type
-        temp = self._drop_not_used_classes_base_on_main_and_sub_types(
+        cycle_lines = self._drop_not_used_classes_base_on_main_and_sub_types(
             self._droppable_types, self._process_result_lines
         )
 
         # Keep rows base on hierarchy list
-        #print(self._process_result_lines)
-        self._process_result_lines = self._keep_rows_base_on_hierarchy_list(
+        hierarchy_lines = self._keep_rows_base_on_hierarchy_list(
             self._hierarkia, self._process_result_lines
         )
-        #print(self._process_result_lines)
-        self._process_result_lines = pd.concat([self._process_result_lines,temp])
+        # Merge hierarchy and cycle lines
+        self._process_result_lines = pd.concat([hierarchy_lines, cycle_lines])
+
+        # Drop dublicates
+        self._process_result_lines.drop_duplicates(subset=["gml_id"], inplace=True)
+
+        # Mark objects which are within YLRE katualueet areas
+        self._process_result_lines = self._check_and_set_ylre_classes_id(self._process_result_lines)
 
         # Buffering configuration
         buffers = self._cfg.buffer(self._module)
@@ -205,22 +221,26 @@ class CycleInfra(GisProcessor):
         target_infra_polys = self._process_result_lines.copy()
         target_infra_polys = self._buffering(target_infra_polys)
 
+        target_infra_polys.rename(columns={"index_right1": "kadun_nimi"}, inplace=True)
         # Drop unnecessary columns
         target_infra_polys = self._drop_unnecessary_columns(
             self._dropped_columns, target_infra_polys
         )
 
         # Dissolve geometries base on attributes listed
-        attrs = ["paatyyppi", "alatyyppi", "silta_alikulku", "hierarkia", "yksisuuntaisuus", ]
+        attrs = ["paatyyppi", "alatyyppi", "silta_alikulku", "hierarkia", "yksisuuntaisuus", "kadun_nimi", ]
         for attr in attrs:
-            target_infra_polys[attr] = target_infra_polys[attr].fillna("")
+            target_infra_polys[attr] = target_infra_polys[attr].fillna("NULL")
 
         target_infra_polys = target_infra_polys.dissolve(by=attrs, aggfunc="sum", as_index=False)
 
         # Explode multipolygon to polygons
         target_infra_polys = target_infra_polys.explode(ignore_index=True)
 
-        #target_infra_polys["geometry"] = target_infra_polys.make_valid()
+        # Validate geometry
+        target_infra_polys = self._makeValid(target_infra_polys, "geometry")
+
+        target_infra_polys = target_infra_polys[~target_infra_polys.is_empty]
         # save to instance
         self._process_result_polygons = target_infra_polys
 
@@ -228,11 +248,9 @@ class CycleInfra(GisProcessor):
         connection = create_engine(self._cfg.pg_conn_uri(), future=True)
 
         if self._store_original_data is not False:
-            self._process_result_polygons.rename_geometry('geom', inplace=True)
-#            self._orig.rename_geometry('geom', inplace=True)
+            self._orig.rename_geometry('geom', inplace=True)
             # persist original data
-#            self._orig.to_postgis(
-            self._process_result_polygons.to_postgis(
+            self._orig.to_postgis(
                 self._store_original_data,
                 connection,
                 "public",

--- a/process/modules/cycling_infra.py
+++ b/process/modules/cycling_infra.py
@@ -70,7 +70,7 @@ class CycleInfra(GisProcessor):
                 "Ulkoilureitti",
                 "Kulkuväylä aukiolla",
                 "Suojatie",
-                "Puistotie- tai väylä",
+#                "Puistotie- tai väylä",
             ],
         }
 
@@ -230,7 +230,7 @@ class CycleInfra(GisProcessor):
         # Dissolve geometries base on attributes listed
         attrs = ["paatyyppi", "alatyyppi", "silta_alikulku", "hierarkia", "yksisuuntaisuus", "kadun_nimi", ]
         for attr in attrs:
-            target_infra_polys[attr] = target_infra_polys[attr].fillna("NULL")
+            target_infra_polys[attr] = target_infra_polys[attr].fillna("")
 
         target_infra_polys = target_infra_polys.dissolve(by=attrs, aggfunc="sum", as_index=False)
 

--- a/process/modules/ylre_katualueet.py
+++ b/process/modules/ylre_katualueet.py
@@ -36,7 +36,7 @@ class YlreKatualueet:
         )
         df = df[~df["ylre_class"].isna()]
         df = df[~(df["geometry"].isna() | df["geometry"].is_empty)].loc[
-            :, ["ylre_class", "geometry"]
+            :, ["ylre_class", "kadun_nimi", "geometry"]
         ]
         df["fid"] = df.reset_index().index
         self._df = df.set_index("fid")


### PR DESCRIPTION
### Description

- Added cycle_infra to automation
- Added own buffer setting for cycle_infra ylre_street_classses
- Changed db connection to use also env variables
- Added field "kadun_nimi" for ylre_katualueet
- Added field "kadun_nimi" for cycle_infra data. This data is from ylre_katualueet.
- Added geometry validation for cycle_infra data
- Cycle_infra data is consist of both by hierarchy and by paatyyppi/alatyyppi

### Jira Issue:
https://helsinkisolutionoffice.atlassian.net/browse/HAI-2342

### Type of change

- [ ] Bug fix
- [X] New feature
- [ ] Other

### Instructions for testing
Instructions can be found from: automation/README.md:

Give following in folder /automation:
`docker build -t haitaton-gis-automation -f ./Dockerfile ..`
This wil build haitaton-gis-automation image.

Run image
Give following:
`docker run --rm --network host --env-file haitaton.env haitaton-gis-automation cycle_infra`

After this Cycle infra data is written to database into the table `tormays_cycle_infra_polys`
and there should be following fields: 
- fid
- paatyyppi
- alatyyppi
- silta_alikulku
- hierarkia
- yksisuuntaisuus
- kadun_nimi
- geom

In local environment there might be situation that table `tormays_cycle_infra_polys` is missing but after docker run table should exists. 