### PR TITLE
HAI-2461 Street class clipping by ylre katuosat

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -45,7 +45,7 @@ ylre_katuosat:
   validate_limit_min: 0.90
   validate_limit_max: 1.15
   buffer:
-    - 5
+    - 0
   store_orinal_data: False
 #  store_orinal_data: "ylre_parts_orig_polys"
 osm:
@@ -71,7 +71,6 @@ tram_infra:
   validate_limit_min: 0.90
   validate_limit_max: 1.15
   buffer:
-    - 4
     - 20
   store_orinal_data: False
 #  store_orinal_data: "tram_infra"
@@ -116,11 +115,11 @@ liikennevaylat:
   validate_limit_min: 0.07
   validate_limit_max: 1.15
   buffer_class_values:
-    paakatu_tai_moottorivayla: 20
-    alueellinen_kokoojakatu: 20
-    paikallinen_kokoojakatu: 20
-    kantakaupungin_asuntokatu_huoltovayla_tai_muu_vahaliikenteinen_katu: 10
-    asuntokatu_huoltovayla_tai_muu_vahaliikenteinen_katu: 10
+    paakatu_tai_moottorivayla: 10
+    alueellinen_kokoojakatu: 7
+    paikallinen_kokoojakatu: 5
+    kantakaupungin_asuntokatu_huoltovayla_tai_muu_vahaliikenteinen_katu: 5
+    asuntokatu_huoltovayla_tai_muu_vahaliikenteinen_katu: 2
   store_orinal_data: False
 #  store_orinal_data: "liikennevaylat"
 central_business_area:

--- a/process/modules/common.py
+++ b/process/modules/common.py
@@ -1,0 +1,49 @@
+import geopandas as gpd
+import pandas as pd
+
+
+def clipAreasByAreas(geometryToClip: gpd.GeoDataFrame, mask: gpd.GeoDataFrame, geometryToClipAttrsDissolve, maskAttrsDissolve, mergeIdField, geometryToClipCheckAttr=None) -> gpd.GeoDataFrame:
+    geometry = geometryToClip[~geometryToClip.is_empty]
+    for attr in maskAttrsDissolve:
+        mask[attr] = mask[attr].fillna("")
+
+    if maskAttrsDissolve:
+        mask_dissolved = mask.dissolve(by=maskAttrsDissolve, as_index=False)
+    else:
+        mask_dissolved = mask
+
+    mask_dissolved = mask_dissolved.explode(ignore_index=True)
+
+    if geometryToClipCheckAttr is not None:
+        geometryToClipOnlyCheckObjects = geometry[geometry[geometryToClipCheckAttr].notnull()]
+        geometryToClipNotCheckObjects = geometry.loc[~geometry[geometryToClipCheckAttr].notnull()]
+    else:
+        geometryToClipOnlyCheckObjects = geometry
+
+    geometryToClipOnlyCheckObjects = geometryToClipOnlyCheckObjects.explode(ignore_index=True)
+    # Actual clipping:
+    clipped_result=gpd.clip(geometryToClipOnlyCheckObjects, mask_dissolved)
+    clipped_result = clipped_result.explode(ignore_index=True)
+
+    # Getting objects which were not clipped
+    merged = geometryToClipOnlyCheckObjects.merge(clipped_result, how="outer", indicator=True, on=mergeIdField, suffixes=("", "_right"))
+    not_clipped = merged[merged["_merge"] == "left_only"].copy()
+    not_clipped.drop("_merge", axis=1, inplace=True)
+    common_columns = set(geometryToClipOnlyCheckObjects.columns).intersection(not_clipped.columns)
+    common_columns.add(geometryToClipOnlyCheckObjects.geometry.name)
+    common_columns_list = list(common_columns)
+    not_clipped = not_clipped[common_columns_list].copy()
+
+    # Adding clipped results to objects which were not checked at all
+    if geometryToClipCheckAttr is not None:
+        retval = gpd.GeoDataFrame(pd.concat([geometryToClipNotCheckObjects, clipped_result], ignore_index=True))
+
+    # Adding not clipped objects
+    retval = gpd.GeoDataFrame(pd.concat([retval, not_clipped], ignore_index=True))
+    for attr in geometryToClipAttrsDissolve:
+        retval[attr] = retval[attr].fillna("")
+    if geometryToClipAttrsDissolve:
+        retval = retval.dissolve(by=geometryToClipAttrsDissolve, as_index=False)
+    retval = retval.explode(ignore_index=True)
+
+    return retval

--- a/process/modules/ylre_katuosat.py
+++ b/process/modules/ylre_katuosat.py
@@ -27,7 +27,7 @@ class YlreKatuosat:
             "Silta - Ajorata, muu (Silta)",
             "Silta - Koroke (Silta)",
         ]
-        df = df[df["ylre_types_concat"].isin(selected_types)].loc[:, ["geometry"]]
+        df = df[df["ylre_types_concat"].isin(selected_types)].loc[:, ["geometry", "kadun_nimi"]]
         df["ylre_street_area"] = 1
         df["fid"] = df.reset_index().index
         self._df = df.set_index("fid")


### PR DESCRIPTION
### Description

* changed buffer values for street classes
* changed buffer value for ylre katuosat
* fixed tram_infra buffer values
* added "kadun_nimi" attribute for ylre_katuosat
* moved ylre_katuosat clipping to common function and taking that inuse at liikennevaylat
* changed liikennevaylat buffering style

### Jira Issue:
https://helsinkisolutionoffice.atlassian.net/browse/HAI-2461

### Type of change

- [ ]  Bug fix
- [x] New feature
- [ ] Other

### Instructions for testing
Instructions can be found from: automation/README.md:

Give following in folder /automation:
`docker build -t haitaton-gis-automation -f ./Dockerfile ..`
This wil build haitaton-gis-automation image.

Run image
Give following:
`docker run --rm --network host --env-file haitaton.env haitaton-gis-automation liikennevaylat`

Remember set all these env variables:
```
HAITATON_USER=
HAITATON_PASSWORD=
HAITATON_HOST=
HAITATON_PORT=
HAITATON_DATABASE=
HELSINKI_EXTRANET_USERNAME=
HELSINKI_EXTRANET_PASSWORD=
```


After this `liikennevaylat` data is written to database into the table `tormays_street_classes_polys`
and there should be following fields:
* fid
* street_class
* silta_alikulku
* geom

And most of the data is clipped by ylre katuosat areas. It might by hard to check but if you run also:
`docker run --rm --network host --env-file haitaton.env haitaton-gis-automation ylre_katuosat`
and then compare `tormays_street_classes_polys` and `tormays_ylre_parts_polys` to each other.

In local environment there might be situation that table tormays_street_classes_polys is missing but after docker run table should exists.

