### PR TITLE
HAI-2565/tram-clip-ylre_katualueet

### DIFF
--- a/README.md
+++ b/README.md
@@ -260,14 +260,15 @@ Files (names configured in `config.yaml`)
 
 ### `tram_infra`
 
-Prerequisite: fetched `osm`, `hki` and `helsinki_osm_lines` -materials.
+Prerequisite: fetched `ylre_katualueet`, `osm`, `hki` and `helsinki_osm_lines` -materials.
 
 Docker example run (ensure that image build and file copying is
 already performed as instructed above):
 
 ```sh
 docker-compose up -d gis-db
-docker-compose run --rm gis-fetch hki osm helsinki_osm_lines
+docker-compose run --rm gis-fetch hki osm helsinki_osm_lines ylre_katualueet
+docker-compose run --rm gis-process ylre_katualueet
 docker-compose run --rm gis-process tram_infra
 docker-compose stop gis-db
 ```
@@ -282,14 +283,15 @@ Output files (names configured in `config.yaml`)
 
 ### `tram_lines`
 
-Prerequisite: fetched `hsl` and `hki` -materials.
+Prerequisite: fetched `ylre_katualueet`, `hsl` and `hki` -materials.
 
 Docker example run (ensure that image build and file copying is
 already performed as instructed above):
 
 ```sh
 docker-compose up -d gis-db
-docker-compose run --rm gis-fetch hki hsl
+docker-compose run --rm gis-fetch hki hsl ylre_katualueet
+docker-compose run --rm gis-process ylre_katualueet
 docker-compose run --rm gis-process tram_lines
 docker-compose stop gis-db
 ```

--- a/automation/automation.sh
+++ b/automation/automation.sh
@@ -9,10 +9,10 @@ do
         sources="${sources} hsl hki"
         ;;
     tram_infra)
-        sources="${sources} hki osm helsinki_osm_lines"
+        sources="${sources} hki osm helsinki_osm_lines ylre_katualueet"
         ;;
     tram_lines)
-        sources="${sources} hki hsl"
+        sources="${sources} hki hsl ylre_katualueet"
         ;;
     liikennevaylat)
         sources="${sources} liikennevaylat central_business_area ylre_katuosat"
@@ -44,6 +44,12 @@ else
             /opt/venv/bin/python /haitaton-gis/process_data.py central_business_area ylre_katuosat $tormays_source
             ;;
         cycle_infra)
+            /opt/venv/bin/python /haitaton-gis/process_data.py ylre_katualueet $tormays_source
+            ;;
+        tram_infra)
+            /opt/venv/bin/python /haitaton-gis/process_data.py ylre_katualueet $tormays_source
+            ;;
+        tram_lines)
             /opt/venv/bin/python /haitaton-gis/process_data.py ylre_katualueet $tormays_source
             ;;
         *)

--- a/config.yaml
+++ b/config.yaml
@@ -68,7 +68,7 @@ tram_infra:
   target_file: "tram_infra.gpkg"
   target_buffer_file: "tormays_tram_infra_polys.gpkg"
   tormays_table_org: "tormays_tram_infra_polys"
-  validate_limit_min: 0.90
+  validate_limit_min: 0.02
   validate_limit_max: 1.15
   buffer:
     - 20
@@ -79,10 +79,10 @@ tram_lines:
   target_file: "tram_lines.gpkg"
   target_buffer_file: "tormays_tram_lines_polys.gpkg"
   tormays_table_org: "tormays_tram_lines_polys"
-  validate_limit_min: 0.90
+  validate_limit_min: 0.35
   validate_limit_max: 2.30
   buffer:
-    - 35
+    - 20
   store_orinal_data: False
 #  store_orinal_data: "tram_lines"
 cycle_infra:

--- a/process/modules/tram_infra.py
+++ b/process/modules/tram_infra.py
@@ -36,10 +36,65 @@ class TramInfra(GisProcessor):
         self._process_result_polygons = None
         self._debug_result_lines = None
         self._orig = None
+        # Loading ylre_katualueet dataset
+        ylre_katualueet_filename = cfg.target_buffer_file("ylre_katualueet")
+        self._ylre_katualueet = gpd.read_file(ylre_katualueet_filename)
+        self._ylre_katualueet_sindex = self._ylre_katualueet.sindex
+
         self._module = "tram_infra"
         self._store_original_data = cfg.store_orinal_data(self._module)
         file_name = cfg.local_file(self._module)
         self._lines = gpd.read_file(file_name)
+
+    def _clipAreasByAreas(self, geometryToClip: gpd.GeoDataFrame, mask: gpd.GeoDataFrame, geometryToClipAttrsDissolve, maskAttrsDissolve, mergeIdField, geometryToClipCheckAttr=None) -> gpd.GeoDataFrame:
+        geometry = geometryToClip[~geometryToClip.is_empty]
+        for attr in maskAttrsDissolve:
+            mask[attr] = mask[attr].fillna("")
+
+        if maskAttrsDissolve:
+            mask_dissolved = mask.dissolve(by=maskAttrsDissolve, as_index=False)
+        else:
+            mask_dissolved = mask
+
+        mask_dissolved = mask_dissolved.explode(ignore_index=True)
+
+        if geometryToClipCheckAttr is not None:
+            geometryToClipOnlyCheckObjects = geometry[geometry[geometryToClipCheckAttr].notnull()]
+            geometryToClipNotCheckObjects = geometry.loc[~geometry[geometryToClipCheckAttr].notnull()]
+        else:
+            geometryToClipOnlyCheckObjects = geometry
+
+        geometryToClipOnlyCheckObjects = geometryToClipOnlyCheckObjects.explode(ignore_index=True)
+        # Actual clipping:
+        clipped_result=gpd.clip(geometryToClipOnlyCheckObjects, mask_dissolved)
+        clipped_result = clipped_result.explode(ignore_index=True)
+        clipped_result.geometry = clipped_result.apply(lambda row: make_valid(row.geometry) if not row.geometry.is_valid else row.geometry, axis=1)
+        geometryToClipOnlyCheckObjects.geometry = geometryToClipOnlyCheckObjects.apply(lambda row: make_valid(row.geometry) if not row.geometry.is_valid else row.geometry, axis=1)
+
+        # Getting objects which were not clipped
+        merged = geometryToClipOnlyCheckObjects.merge(clipped_result, how="outer", indicator=True, on=mergeIdField, suffixes=("", "_right"))
+        not_clipped = merged[merged["_merge"] == "left_only"].copy()
+        not_clipped.drop("_merge", axis=1, inplace=True)
+        common_columns = set(geometryToClipOnlyCheckObjects.columns).intersection(not_clipped.columns)
+        common_columns.add(geometryToClipOnlyCheckObjects.geometry.name)
+        common_columns_list = list(common_columns)
+        not_clipped = not_clipped[common_columns_list].copy()
+
+        # Adding clipped results to objects which were not checked at all
+        if geometryToClipCheckAttr is not None:
+            retval = gpd.GeoDataFrame(pd.concat([geometryToClipNotCheckObjects, clipped_result], ignore_index=True))
+        else:
+            retval = clipped_result
+
+        # Adding not clipped objects
+        retval = gpd.GeoDataFrame(pd.concat([retval, not_clipped], ignore_index=True))
+        for attr in geometryToClipAttrsDissolve:
+            retval[attr] = retval[attr].fillna("")
+        if geometryToClipAttrsDissolve:
+            retval = retval.dissolve(by=geometryToClipAttrsDissolve, as_index=False)
+        retval = retval.explode(ignore_index=True)
+
+        return retval
 
     def process(self):
         lines = self._lines
@@ -68,6 +123,10 @@ class TramInfra(GisProcessor):
         self._process_result_lines = trams.loc[:, ["infra", "geometry"]]
         self._orig = trams
 
+        # Mark objects which are within YLRE katualueet areas
+        self._process_result_lines["id"] = self._process_result_lines.index + 1 # Adding temporary id field for clipping
+        self._process_result_lines = gpd.overlay(self._process_result_lines, self._ylre_katualueet, how='union', keep_geom_type=True).explode().reset_index(drop=True)
+
         # Buffering configuration
         buffers = self._cfg.buffer(self._module)
         if len(buffers) != 1:
@@ -76,6 +135,15 @@ class TramInfra(GisProcessor):
         # buffer lines
         target_infra_polys = self._process_result_lines.copy()
         target_infra_polys["geometry"] = target_infra_polys.buffer(buffers[0])
+
+        # Clip by using YLRE katualueet areas
+        geometryToClipAttrsDissolve = ["infra"]
+        maskAttrsDissolve = ["ylre_class"]
+        target_infra_polys = self._clipAreasByAreas(target_infra_polys, self._ylre_katualueet, geometryToClipAttrsDissolve, maskAttrsDissolve, "id", "ylre_class")
+        target_infra_polys.drop(columns=["id", "ylre_class", "kadun_nimi"], inplace=True) # Dropping temporary id field
+        for attr in geometryToClipAttrsDissolve:
+            target_infra_polys[attr] = target_infra_polys[attr].fillna("")
+        target_infra_polys = target_infra_polys.dissolve(by=geometryToClipAttrsDissolve, as_index=False)
 
         # Only intersecting objects to Helsinki area are important
         # read Helsinki geographical region and reproject
@@ -88,6 +156,8 @@ class TramInfra(GisProcessor):
             raise e
 
         target_infra_polys = gpd.clip(target_infra_polys, helsinki_region_polygon)
+
+        target_infra_polys = target_infra_polys.explode(ignore_index=True)
 
         # save to instance
         self._process_result_polygons = target_infra_polys


### PR DESCRIPTION
### Description
* Added clipping by ylre_katualueet to tram_infra and tram_lines
* Changed config validation limit values
* Updated README
* Changed automation script

### Jira Issue:
https://helsinkisolutionoffice.atlassian.net/browse/HAI-2565

### Type of change
 
- [ ] Bug fix
- [x]  New feature
- [ ]  Other

### Instructions for testing
Instructions can be found from: automation/README.md:

Give following in folder /automation:
`docker build -t haitaton-gis-automation -f ./Dockerfile ..`
This wil build haitaton-gis-automation image.

Run image
Give following:
`docker run --rm --network host --env-file haitaton.env haitaton-gis-automation tram_infra tram_lines`

Remember set all these env variables:

```
HAITATON_USER=
HAITATON_PASSWORD=
HAITATON_HOST=
HAITATON_PORT=
HAITATON_DATABASE=
HELSINKI_EXTRANET_USERNAME=
HELSINKI_EXTRANET_PASSWORD=
```
After this tram_infra and tram_lines data is written to database into the tables `tormays_tram_infra_polys` and `tormays_tram_lines_polys`
and there should be following fields:

- fid
- infra/lines
- geom

And most of the data is clipped by ylre katuelueet areas. It might by hard to check but if you run also:
`docker run --rm --network host --env-file haitaton.env haitaton-gis-automation ylre_katualueet`
and then compare `tormays_tram_infra_polys/tormays_tram_lines_polys` and `tormays_ylre_classes_polys` to each other.

In local environment there might be situation that tables `tormays_tram_infra_polys/tormays_tram_lines_polys` are missing but after docker run tables should exists.

