### PR TITLE
HAI-2237/hsl-clip-ylre_katuosat

### DIFF
--- a/README.md
+++ b/README.md
@@ -177,14 +177,15 @@ Currently supported processing targets are:
 
 ### `hsl`
 
-Prerequisite: downloaded `hsl` and `hki` materials.
+Prerequisite: downloaded ´ylre_katuosat´, `hsl` and `hki` materials.
 
 Docker example run (ensure that image build and file copying is
 already performed as instructed above):
 
 ```sh
 docker-compose up -d gis-db
-docker-compose run --rm gis-fetch hsl hki
+docker-compose run --rm gis-fetch hsl hki ylre_katuosat
+docker-compose run --rm gis-process ylre_katuosat
 docker-compose run --rm gis-process hsl
 docker-compose stop gis-db
 ```

--- a/automation/automation.sh
+++ b/automation/automation.sh
@@ -6,7 +6,7 @@ for tormays_source in $*
 do
     case $tormays_source in
     hsl)
-        sources="${sources} hsl hki"
+        sources="${sources} hsl hki ylre_katuosat"
         ;;
     tram_infra)
         sources="${sources} hki osm helsinki_osm_lines"
@@ -35,6 +35,7 @@ if [ "$RESULT1" != "0" ]; then
     echo -e "Fetching exit Code:" $RESULT1"\nFAILED to fetch data."
     exit 0
 else
+    sources=""
     for tormays_source in $*
     do
         # Process data
@@ -45,6 +46,9 @@ else
             ;;
         cycle_infra)
             /opt/venv/bin/python /haitaton-gis/process_data.py ylre_katualueet $tormays_source
+            ;;
+        hsl)
+            /opt/venv/bin/python /haitaton-gis/process_data.py ylre_katuosat $tormays_source
             ;;
         *)
             /opt/venv/bin/python /haitaton-gis/process_data.py $tormays_source

--- a/automation/automation.sh
+++ b/automation/automation.sh
@@ -52,6 +52,7 @@ else
             ;;
         hsl)
             /opt/venv/bin/python /haitaton-gis/process_data.py ylre_katuosat $tormays_source
+            ;;
         tram_infra)
             /opt/venv/bin/python /haitaton-gis/process_data.py ylre_katualueet $tormays_source
             ;;
@@ -64,7 +65,7 @@ else
         esac
         RESULT2="$?"
         if [ "$RESULT2" != "0" ]; then
-            echo -e "Processing exit Code:" $RESULT1"\nFAILED to process data."
+            echo -e "Processing exit Code:" $RESULT2"\nFAILED to process data."
         else
             # Validate and deploy data
             echo "Validating and deploing $tormays_source ..."

--- a/config.yaml
+++ b/config.yaml
@@ -5,7 +5,7 @@ hsl:
   target_buffer_file: "tormays_buses_polys.gpkg"
   tormays_table_org: "tormays_buses_polys"
   validate_limit_min: 0.90
-  validate_limit_max: 1.15
+  validate_limit_max: 1.24
   buffer:
     - 15
   store_orinal_data: False

--- a/process/modules/hsl.py
+++ b/process/modules/hsl.py
@@ -33,6 +33,11 @@ class HslBuses(GisProcessor):
         if not path.exists(self._cfg.local_file("hki")):
             raise FileNotFoundError("Helsinki city area polygon not found")
 
+        # Loading ylre_katuosat dataset
+        ylre_katuosat_filename = cfg.target_buffer_file("ylre_katuosat")
+        self._ylre_katuosat = gpd.read_file(ylre_katuosat_filename)
+        self._ylre_katuosat_sindex = self._ylre_katuosat.sindex
+
         # TODO: how to obtain this string automatically?
         self._module = "hsl"
         file_name = cfg.local_file(self._module)
@@ -323,11 +328,67 @@ class HslBuses(GisProcessor):
         retval.loc[retval["route_type"] == 702, "trunk"] = "yes"
         return retval
 
+    def _clipAreasByAreas(self, geometryToClip: gpd.GeoDataFrame, mask: gpd.GeoDataFrame, geometryToClipAttrsDissolve, maskAttrsDissolve, mergeIdField, geometryToClipCheckAttr=None) -> gpd.GeoDataFrame:
+        geometry = geometryToClip[~geometryToClip.is_empty]
+        for attr in maskAttrsDissolve:
+            mask[attr] = mask[attr].fillna("")
+
+        if maskAttrsDissolve:
+            mask_dissolved = mask.dissolve(by=maskAttrsDissolve, as_index=False)
+        else:
+            mask_dissolved = mask
+
+        mask_dissolved = mask_dissolved.explode(ignore_index=True)
+
+        if geometryToClipCheckAttr is not None:
+            geometryToClipOnlyCheckObjects = geometry[geometry[geometryToClipCheckAttr].notnull()]
+            geometryToClipNotCheckObjects = geometry.loc[~geometry[geometryToClipCheckAttr].notnull()]
+        else:
+            geometryToClipOnlyCheckObjects = geometry
+
+        geometryToClipOnlyCheckObjects = geometryToClipOnlyCheckObjects.explode(ignore_index=True)
+        # Actual clipping:
+        clipped_result=gpd.clip(geometryToClipOnlyCheckObjects, mask_dissolved)
+        clipped_result = clipped_result.explode(ignore_index=True)
+        clipped_result.geometry = clipped_result.apply(lambda row: make_valid(row.geometry) if not row.geometry.is_valid else row.geometry, axis=1)
+        geometryToClipOnlyCheckObjects.geometry = geometryToClipOnlyCheckObjects.apply(lambda row: make_valid(row.geometry) if not row.geometry.is_valid else row.geometry, axis=1)
+
+        # Getting objects which were not clipped
+        geometryToClipOnlyCheckObjects = geometryToClipOnlyCheckObjects.dissolve(by=geometryToClipAttrsDissolve, as_index=False)
+        clipped_result = clipped_result.dissolve(by=geometryToClipAttrsDissolve, as_index=False)
+        merged = geometryToClipOnlyCheckObjects.merge(clipped_result, how="outer", indicator=True, on=mergeIdField, suffixes=("", "_right"))
+        not_clipped = merged[merged["_merge"] == "left_only"].copy()
+        not_clipped.drop("_merge", axis=1, inplace=True)
+        common_columns = set(geometryToClipOnlyCheckObjects.columns).intersection(not_clipped.columns)
+        common_columns.add(geometryToClipOnlyCheckObjects.geometry.name)
+        common_columns_list = list(common_columns)
+        not_clipped = not_clipped[common_columns_list].copy()
+
+        # Adding clipped results to objects which were not checked at all
+        if geometryToClipCheckAttr is not None:
+            retval = gpd.GeoDataFrame(pd.concat([geometryToClipNotCheckObjects, clipped_result], ignore_index=True))
+        else:
+            retval = clipped_result
+
+        # Adding not clipped objects
+        retval = gpd.GeoDataFrame(pd.concat([retval, not_clipped], ignore_index=True))
+        for attr in geometryToClipAttrsDissolve:
+            retval[attr] = retval[attr].fillna("")
+        if geometryToClipAttrsDissolve:
+            retval = retval.dissolve(by=geometryToClipAttrsDissolve, as_index=False)
+        retval = retval.explode(ignore_index=True)
+
+        return retval
+
     def process(self) -> None:
         # main part of processing is initiated here
         self._process_result_lines = self._process_hsl_bus_lines()
         self._orig = self._process_result_lines
+        self._process_result_lines.to_file("/gis-output/1_process_result_lines.gpkg", driver="GPKG")
 
+        # Mark objects which are within YLRE katuosa areas
+        self._process_result_lines["id"] = self._process_result_lines.index + 1 # Adding temporary id field for clipping
+        self._process_result_lines = gpd.overlay(self._process_result_lines, self._ylre_katuosat, how='union', keep_geom_type=True).explode().reset_index(drop=True)
 
         # Buffering configuration
         buffers = self._cfg.buffer(self._module)
@@ -337,6 +398,32 @@ class HslBuses(GisProcessor):
         # buffer lines
         target_route_polys = self._process_result_lines.copy()
         target_route_polys["geometry"] = target_route_polys.buffer(buffers[0])
+
+        # Clip by using YLRE katuosa areas
+        geometryToClipAttrsDissolve = ["route_id", "direction_id", "rush_hour", "trunk"]
+        maskAttrsDissolve = ["ylre_street_area", "kadun_nimi"]
+        target_route_polys = self._clipAreasByAreas(target_route_polys, self._ylre_katuosat, geometryToClipAttrsDissolve, maskAttrsDissolve, "id", "ylre_street_area")
+        target_route_polys.drop(columns=["id", "ylre_street_area", "kadun_nimi"], inplace=True)
+        for attr in geometryToClipAttrsDissolve:
+            target_route_polys[attr] = target_route_polys[attr].fillna("")
+        target_route_polys = target_route_polys.dissolve(by=geometryToClipAttrsDissolve, as_index=False)
+
+        # Only intersecting objects to Helsinki area are important
+        # read Helsinki geographical region and reproject
+        try:
+            helsinki_region_polygon = gpd.read_file(
+                filename=self._cfg.local_file("hki")
+            ).to_crs(self._cfg.crs())
+        except Exception as e:
+            print("Area polygon file not found!")
+            raise e
+
+        target_route_polys = gpd.clip(target_route_polys, helsinki_region_polygon)
+
+        target_route_polys = target_route_polys.explode(ignore_index=True)
+        target_route_polys["area"] = target_route_polys["geometry"].area
+        target_route_polys = target_route_polys[target_route_polys["area"] > 1000] # Select only objects which area size > 1000
+        target_route_polys.drop(columns=["area"], inplace=True)
 
         # save to instance
         self._process_result_polygons = target_route_polys


### PR DESCRIPTION
### Description
* Added clipping by ylre_katuosat to hsl
* Changed config validation limit values
* Updated README
* Changed automation script
 
### Jira Issue:
https://helsinkisolutionoffice.atlassian.net/browse/HAI-2237

### Type of change

- [ ]  Bug fix
- [x]  New feature
- [ ]  Other

### Instructions for testing
Instructions can be found from: automation/README.md:

Give following in folder /automation:
`docker build -t haitaton-gis-automation -f ./Dockerfile ..`
This wil build haitaton-gis-automation image.

Run image
Give following:
`docker run --rm --network host --env-file haitaton.env haitaton-gis-automation hsl`

Remember set all these env variables:

```
HAITATON_USER=
HAITATON_PASSWORD=
HAITATON_HOST=
HAITATON_PORT=
HAITATON_DATABASE=
HELSINKI_EXTRANET_USERNAME=
HELSINKI_EXTRANET_PASSWORD=
```
After this tram_infra and tram_lines data is written to database into the table tormays_buses_polys
and there should be following fields:

- fid
- route_id
- direction_id
- rush_hour
- trunk
- geom

And most of the data is clipped by ylre katuosat areas. It might by hard to check but if you run also:
`docker run --rm --network host --env-file haitaton.env haitaton-gis-automation ylre_katuosat`
and then compare `tormays_buses_polys` and `tormays_ylre_parts_polys` to each other.

In local environment there might be situation that table `tormays_buses_polys` is missing but after docker run table should exists.