### PR TITLE
HAI-2574/cycling-infra-remove-other-connections

### DIFF
--- a/process/modules/cycling_infra.py
+++ b/process/modules/cycling_infra.py
@@ -225,7 +225,6 @@ class CycleInfra(GisProcessor):
         target_infra_polys = self._process_result_lines.copy()
         target_infra_polys = self._buffering(target_infra_polys)
 
-#        target_infra_polys.rename(columns={"index_right1": "kadun_nimi"}, inplace=True)
         # Drop unnecessary columns
         target_infra_polys = self._drop_unnecessary_columns(
             self._dropped_columns, target_infra_polys


### PR DESCRIPTION
### Description
* Fixed sjoin result column naming
* Added: dropping "Muu yhteys" objects which are not containing "pyörä" string in "alatyyppi"

### Jira Issue:
https://helsinkisolutionoffice.atlassian.net/browse/HAI-2574

### Type of change

- [ ]  Bug fix
- [x] New feature
- [ ] Other

### Instructions for testing
Instructions can be found from: automation/README.md:

Give following in folder /automation:
`docker build -t haitaton-gis-automation -f ./Dockerfile ..`
This wil build haitaton-gis-automation image.

Run image
Give following:
`docker run --rm --network host --env-file haitaton.env haitaton-gis-automation cycle_infra`

Remember set all these env variables:

```
HAITATON_USER=
HAITATON_PASSWORD=
HAITATON_HOST=
HAITATON_PORT=
HAITATON_DATABASE=
HELSINKI_EXTRANET_USERNAME=
HELSINKI_EXTRANET_PASSWORD=
```
After this tram_infra and tram_lines data is written to database into the table tormays_cycle_infra_polys
and there should be following fields:

- fid
- paatyyppi
- alatyyppi
- silta_alikulku
- hierarkia
- yksisuuntaisuus
- kadun_nimi
- geom

And following select clause should not return any lines:
`select * from tormays_cycle_infra_polys tcip where hierarkia ='Muu yhteys' and lower(alatyyppi) not like '%pyörä%';`

In local environment there might be situation that table tormays_cycle_infra_polys is missing but after docker run table should exists.

