### PR TITLE
Use Amazon image cache to avoid Docker Hub rate limit

### DIFF
--- a/automation/Dockerfile
+++ b/automation/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.10
+FROM public.ecr.aws/docker/library/python:3.10
 
 ENV TORMAYS_DEPLOYMENT_PROFILE=docker_development
 


### PR DESCRIPTION
Were getting errors about Docker Hub rate limits:
```
Trying to pull docker.io/library/python:3.10...
time="2024-09-09T07:59:35Z" level=warning msg="Failed, retrying in 1s ... (1/3). Error: initializing source docker://python:3.10: reading manifest 3.10 in docker.io/library/python: toomanyrequests: You have reached your pull rate limit. You may increase the limit by authenticating and upgrading: https://www.docker.com/increase-rate-limit"
time="2024-09-09T08:00:07Z" level=warning msg="Failed, retrying in 2s ... (2/3). Error: initializing source docker://python:3.10: reading manifest 3.10 in docker.io/library/python: toomanyrequests: You have reached your pull rate limit. You may increase the limit by authenticating and upgrading: https://www.docker.com/increase-rate-limit"
time="2024-09-09T08:00:41Z" level=warning msg="Failed, retrying in 4s ... (3/3). Error: initializing source docker://python:3.10: reading manifest 3.10 in docker.io/library/python: toomanyrequests: You have reached your pull rate limit. You may increase the limit by authenticating and upgrading: https://www.docker.com/increase-rate-limit"
Warning: Pull failed, retrying in 5s ...
```

Circumvent this by using AWS image cache. It has a per-minute limit instead a per-day one. We've used this successfully with the backend and UI.

Using the recommended Redhat images is not an option, because gdal is a paid feature there.