### PR TITLE
Use a smaller base image for automation

### DIFF
--- a/automation/Dockerfile
+++ b/automation/Dockerfile
@@ -1,22 +1,25 @@
-FROM public.ecr.aws/docker/library/python:3.10
+FROM ghcr.io/osgeo/gdal:ubuntu-small-latest
 
 ENV TORMAYS_DEPLOYMENT_PROFILE=docker_development
 
 RUN apt-get update  \
     && apt-get install --no-install-recommends -y \
-    gdal-bin \
+    g++ \
     gettext-base \
-    libgdal-dev \
-    python3-launchpadlib  \
-    software-properties-common \
+    python3-dev \
+    python3-venv \
     wget \
+    yq \
     && apt-get clean
-RUN add-apt-repository ppa:rmescandon/yq
-RUN apt-get install --no-install-recommends -y yq && apt-get clean
 
 WORKDIR /opt
 COPY ./automation/requirements.txt /opt
 RUN python -m venv /opt/venv && /opt/venv/bin/pip install --upgrade pip && /opt/venv/bin/pip install -r requirements.txt
+
+# Clean-up
+RUN apt-get remove -y --purge g++
+RUN apt-get autoremove -y
+RUN rm -rfv /var/lib/apt/lists/*
 
 COPY ./automation/automation.sh /haitaton-automation/
 COPY ./config.yaml /haitaton-gis/

--- a/fetch/Dockerfile
+++ b/fetch/Dockerfile
@@ -5,11 +5,9 @@ RUN apt-get update  \
     gdal-bin \
     gettext-base \
     libgdal-dev \
-    python3-launchpadlib  \
     software-properties-common \
     wget \
+    yq \
     && apt-get clean
-RUN add-apt-repository ppa:rmescandon/yq
-RUN apt-get install --no-install-recommends -y yq && apt-get clean
 
 ENTRYPOINT [ "sh", "/haitaton-gis/fetch_all.sh" ]


### PR DESCRIPTION
Use a smaller base image for automation to reduce the size of the final deployable image. The size dropped from 1.89GB to 1.19GB.

The new image also has both gdal and python included, so there's less need to customize, slightly reducing the build times.

yq no longer needs a launchpad ppa to be installed. This is also true for the fetch Dockerfile.