### PR TITLE
Use idiomatic logging pattern

### DIFF
--- a/automation/automation.sh
+++ b/automation/automation.sh
@@ -73,7 +73,7 @@ else
         echo -e "Processing exit Code:" $RESULT2"\nFAILED to process data."
     else
         # Validate and deploy data
-        echo "Validating and deploing ${org_sources} ..."
+        echo "Validating and deploying ${org_sources} ..."
         /opt/venv/bin/python /haitaton-gis-validate-deploy/validate_deploy_data.py ${org_sources}
         echo "Deployed ${org_sources}."
     fi

--- a/config.yaml
+++ b/config.yaml
@@ -133,12 +133,6 @@ central_business_area:
   store_orinal_data: False
 #  store_orinal_data: "Piirijako_pienalue"
 
-logging:
-  logging_filename: ""
-  logging_filemode: "w"
-  logging_level: INFO
-  logging_format: "%(asctime)s - %(levelname)s - %(message)s"
-
 common:
   download_path: "/downloads"
   crs: "EPSG:3879"

--- a/process/modules/hsl.py
+++ b/process/modules/hsl.py
@@ -1,3 +1,4 @@
+import logging
 from datetime import date, timedelta, datetime, time
 from functools import partial
 import geopandas as gpd
@@ -5,8 +6,6 @@ import gtfs_kit as gk
 from os import path
 import pandas as pd
 from parse import parse
-import re
-import fiona
 from shapely.errors import ShapelyDeprecationWarning
 from shapely.geometry import Point, LineString
 from sqlalchemy import create_engine
@@ -16,6 +15,7 @@ import warnings
 from modules.config import Config
 from modules.gis_processing import GisProcessor
 
+logger = logging.getLogger(__name__)
 
 def as_date(d: str) -> date:
     """Convert string representation to date object"""
@@ -58,8 +58,8 @@ class HslBuses(GisProcessor):
         """Read feed data from zip file"""
         try:
             feed = (gk.read_feed(file_name, dist_units="km"))
-        except Exception as error:
-            print("An error occurred:", error)
+        except Exception:
+            logger.exception("An error occurred:")
             exit()
         return feed
 
@@ -309,7 +309,7 @@ class HslBuses(GisProcessor):
                 filename=self._cfg.local_file("hki")
             ).to_crs(self._cfg.crs())
         except Exception as e:
-            print("Area polygon file not found!")
+            logger.error("Area polygon file not found!")
             raise e
 
         target_routes = (
@@ -421,7 +421,7 @@ class HslBuses(GisProcessor):
                 filename=self._cfg.local_file("hki")
             ).to_crs(self._cfg.crs())
         except Exception as e:
-            print("Area polygon file not found!")
+            logger.error("Area polygon file not found!")
             raise e
 
         target_route_polys = gpd.clip(target_route_polys, helsinki_region_polygon)

--- a/process/modules/tram_infra.py
+++ b/process/modules/tram_infra.py
@@ -1,10 +1,12 @@
+import logging
 import geopandas as gpd
 import pandas as pd
-import fiona
-from sqlalchemy import create_engine, text
+from sqlalchemy import create_engine
 
 from modules.config import Config
 from modules.gis_processing import GisProcessor
+
+logger = logging.getLogger(__name__)
 
 # SettingWithCopyWarning warning disabling
 pd.options.mode.chained_assignment = None
@@ -153,7 +155,7 @@ class TramInfra(GisProcessor):
                 filename=self._cfg.local_file("hki")
             ).to_crs(self._cfg.crs())
         except Exception as e:
-            print("Area polygon file not found!")
+            logger.error("Area polygon file not found!")
             raise e
 
         target_infra_polys = gpd.clip(target_infra_polys, helsinki_region_polygon)

--- a/process/modules/tram_lines.py
+++ b/process/modules/tram_lines.py
@@ -1,3 +1,4 @@
+import logging
 import geopandas as gpd
 import pandas as pd
 from sqlalchemy import create_engine
@@ -5,7 +6,6 @@ import gtfs_kit as gk
 from shapely.errors import ShapelyDeprecationWarning
 from shapely.geometry import LineString, Point
 import warnings
-import fiona
 
 from modules.config import Config
 from modules.gis_processing import GisProcessor
@@ -15,6 +15,8 @@ from modules.gis_processing import GisProcessor
 # 900 = Light rail
 
 TRAM_ROUTE_TYPE = [0, 900]
+
+logger = logging.getLogger(__name__)
 
 class TramLines(GisProcessor):
     """Process tram lines, i.e. schedule information."""
@@ -162,7 +164,7 @@ class TramLines(GisProcessor):
                 filename=self._cfg.local_file("hki")
             ).to_crs(self._cfg.crs())
         except Exception as e:
-            print("Area polygon file not found!")
+            logger.error("Area polygon file not found!")
             raise e
 
         target_lines_polys = gpd.clip(target_lines_polys, helsinki_region_polygon)

--- a/process/process_data.py
+++ b/process/process_data.py
@@ -1,5 +1,6 @@
 """Main entrypoint script for material processing.
 """
+import logging
 import os
 import sys
 
@@ -20,7 +21,7 @@ DEFAULT_DEPLOYMENT_PROFILE = "local_development"
 
 
 def process_item(item: str, cfg: Config):
-    print(f"Processing item: {item}")
+    logger.info("Processing item: %s", item)
     gis_processor = instantiate_processor(item, cfg)
     gis_processor.process()
     gis_processor.persist_to_database()
@@ -49,23 +50,22 @@ def instantiate_processor(item: str, cfg: Config) -> GisProcessor:
     elif item == "central_business_area":
         return CentralBusinessAreas(cfg)
     else:
-        try:
-            raise RuntimeError("Configuration not recognized: {}".format(item))
-        except Exception as e:
-            print("{}".format(e))
+        logger.error("Configuration not recognized: %s", item)
 
 
 if __name__ == "__main__":
+    FORMAT = "%(asctime)s - %(levelname)-5s - %(name)-15s - %(message)s"
+    logging.basicConfig(format=FORMAT, level=logging.INFO)
+    logger = logging.getLogger(__name__)
 
     deployment_profile = os.environ.get("TORMAYS_DEPLOYMENT_PROFILE")
     use_deployment_profile = DEFAULT_DEPLOYMENT_PROFILE
     if deployment_profile in ["local_docker_development", "local_development", "docker_development"]:
         use_deployment_profile = deployment_profile
     else:
-        print(
-            "Deployment profile environment variable is not set, defaulting to '{}'".format(
-                DEFAULT_DEPLOYMENT_PROFILE
-            )
+        logger.info(
+            "Deployment profile environment variable is not set, defaulting to %s",
+            DEFAULT_DEPLOYMENT_PROFILE,
         )
 
     cfg = Config().with_deployment_profile(use_deployment_profile)

--- a/validate-deploy/modules/autoliikennemaarat.py
+++ b/validate-deploy/modules/autoliikennemaarat.py
@@ -1,12 +1,15 @@
 import logging
 
 from modules.config import Config
-from modules.common import *
+from modules.common import validate_data_count_limits, deploy
 from modules.gis_validate_deploy import GisProcessor
 import geopandas as gpd
 
+
 class MakaAutoliikennemaarat(GisProcessor):
     """Process traffic (car) volumes."""
+
+    logger = logging.getLogger(__name__)
 
     def __init__(self, cfg: Config):
         self._module = "maka_autoliikennemaarat"
@@ -18,11 +21,10 @@ class MakaAutoliikennemaarat(GisProcessor):
     def get_temp_data(self):
         for buffer in self._buffers:
             buffer_data = gpd.read_file(self._filename.format(buffer))
-            buffer_data.rename_geometry('geom', inplace=True)
+            buffer_data.rename_geometry("geom", inplace=True)
             self._tormays_files_temp[buffer] = buffer_data
 
     def validate_deploy(self):
-
         # validate data amount: is it between given limits
         validate_result = False
 
@@ -35,14 +37,16 @@ class MakaAutoliikennemaarat(GisProcessor):
                 self._validate_limit_min,
                 self._validate_limit_max,
                 self._filename.format(buffer),
-                self._logger
-                )
+                self.logger,
+            )
             if validate_result is True:
                 self._deploy_result = deploy(
                     self._pg_conn_uri,
                     self._tormays_table_org.format(buffer),
                     self._tormays_files_temp[buffer],
-                    self._logger
-                    )
+                    self.logger,
+                )
             else:
-                logging.error("Validation failed(" + self._module + "_" + str(buffer) + "). No deploy")
+                self.logger.error(
+                    "Validation failed(%s_%u). No deploy", self._module, buffer
+                )

--- a/validate-deploy/modules/central_business_area.py
+++ b/validate-deploy/modules/central_business_area.py
@@ -1,8 +1,11 @@
+import logging
 from modules.config import Config
 from modules.gis_validate_deploy import GisProcessor
 
 class CentralBusinessAreas(GisProcessor):
     """Process Central Business Areas"""
+
+    logger = logging.getLogger(__name__)
 
     def __init__(self, cfg: Config):
         self._module = "central_business_area"

--- a/validate-deploy/modules/common.py
+++ b/validate-deploy/modules/common.py
@@ -2,6 +2,7 @@ import math
 from sqlalchemy import create_engine, text
 from sqlalchemy.exc import ProgrammingError
 
+
 def get_data_count(pg_conn_uri, counted_table, logger=None):
     data_amount = None
     sql = "select count(*) lkm from " + counted_table + " where geom is not null"
@@ -9,13 +10,13 @@ def get_data_count(pg_conn_uri, counted_table, logger=None):
     with engine.connect() as connection:
         try:
             count_result = connection.execute(text(sql)).fetchall()
-        except ProgrammingError as e:
+        except ProgrammingError:
             data_amount = -1
             count_result = None
-            logger.error(f"Error: {e}")
-        except Exception as e:
+            logger.exception()
+        except Exception:
             count_result = None
-            logger.error(f"Error: {e}")
+            logger.exception()
 
     if count_result:
         for row in count_result:
@@ -23,18 +24,24 @@ def get_data_count(pg_conn_uri, counted_table, logger=None):
 
     return data_amount
 
-def validate_data_count_limits(module, pg_conn_uri, tormays_table_org, tormays_file_temp, validate_limit_min, validate_limit_max, filename, logger=None):
+def validate_data_count_limits(module, pg_conn_uri, tormays_table_org, tormays_file_temp, validate_limit_min, validate_limit_max, filename, logger):
     """validate data amount: is it between given limits"""
     logger.info("Data amount validation started")
-    logger.info(f"Module: {module}")
+    logger.info("Module: %s", module)
     old_amount = get_data_count(pg_conn_uri, tormays_table_org, logger)
-    logger.info(f"Old data amount ({tormays_table_org}): {old_amount}")
+    logger.info("Old data amount (%s): %u", tormays_table_org, old_amount)
     new_amount = len(tormays_file_temp)
-    logger.info(f"New data amount ({filename}): {new_amount}")
-    if new_amount and old_amount and validate_limit_min and validate_limit_max and old_amount != -1:
-        min_limit = math.floor(validate_limit_min*old_amount)
-        max_limit = math.ceil(validate_limit_max*old_amount)
-        logger.info(f"Limits: {min_limit} <= new amount <= {max_limit}")
+    logger.info("New data amount (%s): %u", filename, new_amount)
+    if (
+        new_amount
+        and old_amount
+        and validate_limit_min
+        and validate_limit_max
+        and old_amount != -1
+    ):
+        min_limit = math.floor(validate_limit_min * old_amount)
+        max_limit = math.ceil(validate_limit_max * old_amount)
+        logger.info("Limits: %u <= new amount <= %u", min_limit, max_limit)
         if new_amount < min_limit:
             logger.error("Data amount validation failed: Data amount is Below given limits")
             return False
@@ -45,13 +52,14 @@ def validate_data_count_limits(module, pg_conn_uri, tormays_table_org, tormays_f
             logger.info("Data amount is within given limits")
             return True
     elif old_amount == -1:
-        logger.error(f"Tormays table {tormays_table_org} not exists.")
+        logger.error("Tormays table %s does not exist.", tormays_table_org)
         return True
     else:
         logger.error("Data amount validation failed because of missing configuration.")
         return False
 
-def deploy(pg_conn_uri, tormays_table_org, tormays_file_temp, logger=None):
+
+def deploy(pg_conn_uri, tormays_table_org, tormays_file_temp, logger):
     engine = create_engine(pg_conn_uri)
     with engine.connect() as connection:
         transaction = connection.begin()
@@ -64,9 +72,13 @@ def deploy(pg_conn_uri, tormays_table_org, tormays_file_temp, logger=None):
                 if_exists="replace",
                 index=True,
                 index_label="fid",
-                )
+            )
             transaction.commit()
-            logger.info(f"Uploaded new data into table {tormays_table_org}: {len(tormays_file_temp)} rows")
-        except Exception as e:
+            logger.info(
+                "Uploaded new data into table %s: %u rows",
+                tormays_table_org,
+                len(tormays_file_temp),
+            )
+        except Exception:
             # Transaction implicitly rolls back if an exception occurred within the "with" block
-            logger.error(f"Error: {e}")
+            logger.exception()

--- a/validate-deploy/modules/config.py
+++ b/validate-deploy/modules/config.py
@@ -1,5 +1,4 @@
 from __future__ import annotations
-from os.path import exists
 from pathlib import Path
 import yaml
 import os
@@ -108,19 +107,3 @@ class Config:
             port=os.environ.get("HAITATON_PORT",self._cfg.get(deployment, {}).get("database").get("port")),
             dbname=os.environ.get("HAITATON_DATABASE",self._cfg.get(deployment, {}).get("database").get("database")),
             )
-
-    def logging_filename(self) -> str:
-        """Return logging file name information from config file."""
-        return self._cfg.get("logging").get("logging_filename")
-
-    def logging_filemode(self) -> str:
-        """Return logging file mode information from config file."""
-        return self._cfg.get("logging").get("logging_filemode")
-
-    def logging_level(self) -> str:
-        """Return logging file level information from config file."""
-        return self._cfg.get("logging").get("logging_level")
-
-    def logging_format(self) -> str:
-        """Return logging file level information from config file."""
-        return self._cfg.get("logging").get("logging_format")

--- a/validate-deploy/modules/cycling_infra.py
+++ b/validate-deploy/modules/cycling_infra.py
@@ -1,11 +1,12 @@
 import logging
 
 from modules.config import Config
-from modules.common import *
 from modules.gis_validate_deploy import GisProcessor
 
 class CycleInfra(GisProcessor):
     """Process cycle route infra."""
+
+    logger = logging.getLogger(__name__)
 
     def __init__(self, cfg: Config):
         self._module = "cycle_infra"

--- a/validate-deploy/modules/gis_validate_deploy.py
+++ b/validate-deploy/modules/gis_validate_deploy.py
@@ -1,29 +1,25 @@
-import logging
-
 from abc import ABC, abstractmethod
 from modules.common import validate_data_count_limits, deploy
 import geopandas as gpd
 
 
 class GisProcessor(ABC):
-    """ This class helps keeping interface consistent."""
+    """This class helps keeping interface consistent."""
+
+    @property
+    @abstractmethod
+    def logger(self):
+        """A logger object (can be a class attribute) to log messages to."""
 
     def __init__(self, cfg):
         self._tormays_table_org = cfg.tormays_table_org(self._module)
         self._validate_limit_min = cfg.validate_limit_min(self._module)
         self._validate_limit_max = cfg.validate_limit_max(self._module)
         self._pg_conn_uri = cfg.pg_conn_uri()
-        logging.basicConfig(
-            filename=cfg.logging_filename().format(self._module),
-            filemode=cfg.logging_filemode(),
-            format=cfg.logging_format()
-            )
-        self._logger = logging.getLogger()
-        self._logger.setLevel(cfg.logging_level())
 
     def get_temp_data(self):
         self._tormays_file_temp = gpd.read_file(self._filename)
-        self._tormays_file_temp.rename_geometry('geom', inplace=True)
+        self._tormays_file_temp.rename_geometry("geom", inplace=True)
 
     def validate_deploy(self):
         # validate data amount: is it between given limits
@@ -35,8 +31,8 @@ class GisProcessor(ABC):
             self._validate_limit_min,
             self._validate_limit_max,
             self._filename,
-            self._logger
-            )
+            self.logger,
+        )
 
         # Valid --> deploy
         if validate_result is True:
@@ -44,7 +40,7 @@ class GisProcessor(ABC):
                 self._pg_conn_uri,
                 self._tormays_table_org,
                 self._tormays_file_temp,
-                self._logger
-                )
+                self.logger,
+            )
         else:
-            logging.error("Validation failed (" + self._module + "). No deploy")
+            self.logger.error("Validation failed (%s). No deploy.", self._module)

--- a/validate-deploy/modules/hsl.py
+++ b/validate-deploy/modules/hsl.py
@@ -1,11 +1,12 @@
 import logging
 
 from modules.config import Config
-from modules.common import *
 from modules.gis_validate_deploy import GisProcessor
 
 class HslBuses(GisProcessor):
     """Process HSL bus lines."""
+
+    logger = logging.getLogger(__name__)
 
     def __init__(self, cfg: Config):
         self._module = "hsl"

--- a/validate-deploy/modules/liikennevaylat.py
+++ b/validate-deploy/modules/liikennevaylat.py
@@ -1,11 +1,12 @@
 import logging
 
 from modules.config import Config
-from modules.common import *
 from modules.gis_validate_deploy import GisProcessor
 
 class Liikennevaylat(GisProcessor):
     """Process street classes infra."""
+
+    logger = logging.getLogger(__name__)
 
     def __init__(self, cfg: Config):
         self._module = "liikennevaylat"

--- a/validate-deploy/modules/tram_infra.py
+++ b/validate-deploy/modules/tram_infra.py
@@ -1,11 +1,12 @@
 import logging
 
 from modules.config import Config
-from modules.common import *
 from modules.gis_validate_deploy import GisProcessor
 
 class TramInfra(GisProcessor):
     """Process tram infra."""
+
+    logger = logging.getLogger(__name__)
 
     def __init__(self, cfg: Config):
         self._module = "tram_infra"

--- a/validate-deploy/modules/tram_lines.py
+++ b/validate-deploy/modules/tram_lines.py
@@ -1,11 +1,12 @@
 import logging
 
 from modules.config import Config
-from modules.common import *
 from modules.gis_validate_deploy import GisProcessor
 
 class TramLines(GisProcessor):
     """Process tram lines, i.e. schedule information."""
+
+    logger = logging.getLogger(__name__)
 
     def __init__(self, cfg: Config):
         self._module = "tram_lines"

--- a/validate-deploy/modules/ylre_katualueet.py
+++ b/validate-deploy/modules/ylre_katualueet.py
@@ -1,11 +1,12 @@
 import logging
 
 from modules.config import Config
-from modules.common import *
 from modules.gis_validate_deploy import GisProcessor
 
 class YlreKatualueet(GisProcessor):
     """Process YLRE street areas"""
+
+    logger = logging.getLogger(__name__)
 
     def __init__(self, cfg: Config):
         self._module = "ylre_katualueet"

--- a/validate-deploy/modules/ylre_katuosat.py
+++ b/validate-deploy/modules/ylre_katuosat.py
@@ -1,11 +1,12 @@
 import logging
 
 from modules.config import Config
-from modules.common import *
 from modules.gis_validate_deploy import GisProcessor
 
 class YlreKatuosat(GisProcessor):
     """Process YLRE parts"""
+
+    logger = logging.getLogger(__name__)
 
     def __init__(self, cfg: Config):
         self._module = "ylre_katuosat"

--- a/validate-deploy/validate_deploy_data.py
+++ b/validate-deploy/validate_deploy_data.py
@@ -2,6 +2,7 @@
 """
 import os
 import sys
+import logging
 
 from modules.config import Config
 from modules.gis_validate_deploy import GisProcessor
@@ -45,16 +46,19 @@ def instantiate_processor(item: str, cfg: Config) -> GisProcessor:
     elif item == "central_business_area":
         return CentralBusinessAreas(cfg)
     else:
-        print("{}".format(RuntimeError("Configuration not recognized: {}".format(item))))
+        logger.error("Configuration not recognized: {}".format(item))
 
 if __name__ == "__main__":
+    FORMAT = '%(asctime)s - %(levelname)-5s - %(name)-15s - %(message)s'
+    logging.basicConfig(format=FORMAT, level=logging.INFO)
+    logger = logging.getLogger(__name__)
 
     deployment_profile = os.environ.get("TORMAYS_DEPLOYMENT_PROFILE")
     use_deployment_profile = DEFAULT_DEPLOYMENT_PROFILE
     if deployment_profile in ["local_docker_development", "local_development", "docker_development"]:
         use_deployment_profile = deployment_profile
     else:
-        print(
+        logger.info(
             "Deployment profile environment variable is not set, defaulting to '{}'".format(
                 DEFAULT_DEPLOYMENT_PROFILE
             )


### PR DESCRIPTION
Simplify the logging setup by using the idiomatic Python pattern for logging (https://docs.python.org/3/library/logging.html).

Add logger name to the logging pattern. For internal logging, this is the name of the module being processed. We part from the idiomatic pattern to keep the logger name of the module for functions in the parent class and in shared libararies.

Replace all remaining print calls with logging calls. Format the log messages with the logging function, replacing string concatenation and external formatting.

Also remove some unused imports and reformat some code segments and files with Ruff formatter.