### PR TITLE
HAI-2672/remove-puistotie-and-vayla-from-cycling-infra

### DIFF
--- a/process/modules/cycling_infra.py
+++ b/process/modules/cycling_infra.py
@@ -70,7 +70,7 @@ class CycleInfra(GisProcessor):
                 "Ulkoilureitti",
                 "Kulkuväylä aukiolla",
                 "Suojatie",
-#                "Puistotie- tai väylä",
+                "Puistotie- tai väylä",
             ],
         }
 


### PR DESCRIPTION
### Description
Removed "Puistotie- tai väylä" objects from processing.

### Jira Issue:
https://helsinkisolutionoffice.atlassian.net/browse/HAI-2672

### Type of change
- [ ]  Bug fix
- [ ] New feature
- [x] Other

### Instructions for testing
Instructions can be found from: automation/README.md:

Give following in folder /automation:
`docker build -t haitaton-gis-automation -f ./Dockerfile ..`
This wil build haitaton-gis-automation image.

Run image
Give following:
`docker run --rm --network host --env-file haitaton.env haitaton-gis-automation cycle_infra`

Remember set all these env variables:

```
HAITATON_USER=
HAITATON_PASSWORD=
HAITATON_HOST=
HAITATON_PORT=
HAITATON_DATABASE=
HELSINKI_EXTRANET_USERNAME=
HELSINKI_EXTRANET_PASSWORD=
```
When checking processed data from `tormays_cycle_infra_polys` there is less coverage than earlier.