### PR TITLE
Fix for error logging

### DIFF
--- a/validate-deploy/modules/common.py
+++ b/validate-deploy/modules/common.py
@@ -13,10 +13,10 @@ def get_data_count(pg_conn_uri, counted_table, logger=None):
         except ProgrammingError:
             data_amount = -1
             count_result = None
-            logger.exception()
+            logger.warn("Programming error while getting table data counts.", exc_info=True)
         except Exception:
             count_result = None
-            logger.exception()
+            logger.exception("Unknown exception getting table data counts.")
 
     if count_result:
         for row in count_result:
@@ -52,7 +52,7 @@ def validate_data_count_limits(module, pg_conn_uri, tormays_table_org, tormays_f
             logger.info("Data amount is within given limits")
             return True
     elif old_amount == -1:
-        logger.error("Tormays table %s does not exist.", tormays_table_org)
+        logger.warn("Tormays table %s does not exist.", tormays_table_org)
         return True
     else:
         logger.error("Data amount validation failed because of missing configuration.")
@@ -81,4 +81,4 @@ def deploy(pg_conn_uri, tormays_table_org, tormays_file_temp, logger):
             )
         except Exception:
             # Transaction implicitly rolls back if an exception occurred within the "with" block
-            logger.exception()
+            logger.exception("Exception while deploying.")


### PR DESCRIPTION
Exception logging is failing. The exceptions log statements require a message, or it will generate another exception. Add a message to fix the logging.

This was blocking the creation of a tormays table if it was missing.

Also, changed some none-critical log messages to warning instead of error.