### PR TITLE
HAI-2847/cycling-infra-buffering-modifications

### DIFF
--- a/process/modules/cycling_infra.py
+++ b/process/modules/cycling_infra.py
@@ -83,11 +83,6 @@ class CycleInfra(GisProcessor):
         # Buffering classes
         self._buffer_class_yksisuuntaisuus_values = {
             "kaista": [
-                  "NoneNone",
-                  "BaanaNone",
-                  "Muu pyöräreittiNone",
-                  "Muu yhteysNone",
-                  "PääpyöräreittiNone",
             ],
             "yksisuuntainen": [
                   "NoneYksisuuntainen digitointisuuntaan",
@@ -107,12 +102,17 @@ class CycleInfra(GisProcessor):
                   "PääpyöräreittiYksisuuntainen digitointisuuntaa vastaan",
             ],
             "kaksisuuntainen": [
+                  "NoneNone",
+                  "Muu pyöräreittiNone",
+                  "Muu yhteysNone",
+                  "PääpyöräreittiNone",
                   "NoneKaksisuuntainen",
                   "Muu pyöräreittiKaksisuuntainen",
                   "Muu yhteysKaksisuuntainen",
                   "PääpyöräreittiKaksisuuntainen",
             ],
             "kaksisuuntainen_baana": [
+                  "BaanaNone",
                   "BaanaKaksisuuntainen",
             ],
         }


### PR DESCRIPTION
Small change which effects how to buffer objects which are not having "yksisuuntaisuus" value. 
Objects which "yksisuuntaisuus" value  is None should have same buffering than objects with "kaksisuuntainen" value except class "Baana" where default buffering should same than "Baana" "kaksisuuntainen".