### PR TITLE
HAI-3467: Add-missing-cycle-class-items-to-buffer-classes

### DIFF
--- a/process/modules/cycling_infra.py
+++ b/process/modules/cycling_infra.py
@@ -55,7 +55,6 @@ class CycleInfra(GisProcessor):
                 "Paikallinen kokoojakatu",
                 "Päätie",
                 "Tonttikatu",
-                #"Yhdistetty jalkakäytävä ja pyörätie",
             ],
             "Muu väylä": [
                 "Väylälinkki",
@@ -63,6 +62,7 @@ class CycleInfra(GisProcessor):
                 "Jalkakäytävä",
                 "Kulkuväylä aukiolla",
                 "Huoltotie",
+                "Alueellinen kokoojakatu",
             ],
             "Jalankulku ja pyöräliikenne": [
                 "Jalkakäytävä",
@@ -70,7 +70,6 @@ class CycleInfra(GisProcessor):
                 "Ulkoilureitti",
                 "Kulkuväylä aukiolla",
                 "Suojatie",
-#                "Puistotie- tai väylä",
             ],
         }
 
@@ -100,6 +99,9 @@ class CycleInfra(GisProcessor):
                   "PääpyöräreittiYksisuuntainen digitointisuuntaan",
                   "PääpyöräreittiYksisuuntainen (ei tietoa digitointisuunnasta)",
                   "PääpyöräreittiYksisuuntainen digitointisuuntaa vastaan",
+                  "Yksisuuntainen digitointisuuntaan",
+                  "Yksisuuntainen (ei tietoa digitointisuunnasta)",
+                  "Yksisuuntainen digitointisuuntaa vastaan",
             ],
             "kaksisuuntainen": [
                   "NoneNone",
@@ -110,10 +112,15 @@ class CycleInfra(GisProcessor):
                   "Muu pyöräreittiKaksisuuntainen",
                   "Muu yhteysKaksisuuntainen",
                   "PääpyöräreittiKaksisuuntainen",
+                  "Muu pyöräreitti",
+                  "Muu yhteys",
+                  "Pääpyöräreitti",
+                  "Kaksisuuntainen",
             ],
             "kaksisuuntainen_baana": [
                   "BaanaNone",
                   "BaanaKaksisuuntainen",
+                  "Baana",
             ],
         }
 


### PR DESCRIPTION
### Description
Added new classes to buffering class and one new droppable type.

### Jira Issue:
https://helsinkisolutionoffice.atlassian.net/browse/HAI-3467

### Type of change

- [ ] Bug fix
- [ ]  New feature
- [x] Other

### Instructions for testing
Instructions can be found from: automation/README.md:

Give following in folder /automation:
`docker build -t haitaton-gis-automation -f ./Dockerfile ..`
This wil build haitaton-gis-automation image.

Run image
Give following:
`docker run --rm --network host --env-file haitaton.env haitaton-gis-automation cycle_infra`

Remember set all these env variables:

```
HAITATON_USER=
HAITATON_PASSWORD=
HAITATON_HOST=
HAITATON_PORT=
HAITATON_DATABASE=
HELSINKI_EXTRANET_USERNAME=
HELSINKI_EXTRANET_PASSWORD=
```
After this cycle_infra data is written to database into the table tormays_cycle_infra_polys
and there should be following fields:
```
fid
paatyyppi
alatyyppi
silta_alikulku
hierarkia
yksisuuntaisuus
kadun_nimi
geom
```
Data amount should be over 17000 rows.

In local environment there might be situation that table tormays_cycle_infra_polys is missing but after docker run table should exists.