### PR TITLE
Added and removed main and sub types of street classes

### DIFF
--- a/process/modules/liikennevaylat.py
+++ b/process/modules/liikennevaylat.py
@@ -104,6 +104,7 @@ class Liikennevaylat(GisProcessor):
                 "Jalkakäytävän tasossa oleva pyörätie",
                 "Muu polku",
                 "Tasoeroteltu pyörätie",
+                "Pyörätie",
             ],
             "Muu väylä": [
                 "Väylälinkki",
@@ -128,45 +129,19 @@ class Liikennevaylat(GisProcessor):
 
         # Set street_classes base on main and sub type combinations (main,sub,street_class)
         self._street_class_name_base_on_main_and_sub_type = (
-            (
-                "Katu",
-                "Asuntokatu",
-                "Asuntokatu, huoltoväylä tai muu vähäliikenteinen katu",
-            ),
+            ("Katu", "Asuntokatu", "Asuntokatu, huoltoväylä tai muu vähäliikenteinen katu"),
             ("Katu", "Paikallinen kokoojakatu", "Paikallinen kokoojakatu"),
             ("Katu", "Alueellinen kokoojakatu", "Alueellinen kokoojakatu"),
+            ("Muu väylä", "Alueellinen kokoojakatu", "Alueellinen kokoojakatu"),
             ("Katu", "Päätie", "Pääkatu tai moottoriväylä"),
-            (
-                "Muu väylä",
-                "Huoltotie",
-                "Asuntokatu, huoltoväylä tai muu vähäliikenteinen katu",
-            ),
+            ("Muu väylä", "Huoltotie", "Asuntokatu, huoltoväylä tai muu vähäliikenteinen katu"),
+            ("Katu", "Huoltotie", "Asuntokatu, huoltoväylä tai muu vähäliikenteinen katu"),
             ("Katu", "Moottoriväylä", "Pääkatu tai moottoriväylä"),
-            (
-                "Katu",
-                "Tonttikatu",
-                "Asuntokatu, huoltoväylä tai muu vähäliikenteinen katu",
-            ),
-            (
-                "Kevyt liikenne",
-                "Piha- ja/tai kävelykatu",
-                "Asuntokatu, huoltoväylä tai muu vähäliikenteinen katu",
-            ),
-            (
-                "Kevyt liikenne",
-                "Pyöräkatu",
-                "Asuntokatu, huoltoväylä tai muu vähäliikenteinen katu",
-            ),
-            (
-                "Jalankulku ja pyöräliikenne",
-                "Piha- ja/tai kävelykatu",
-                "Asuntokatu, huoltoväylä tai muu vähäliikenteinen katu",
-            ),
-            (
-                "Jalankulku ja pyöräliikenne",
-                "Pyöräkatu",
-                "Asuntokatu, huoltoväylä tai muu vähäliikenteinen katu",
-            ),
+            ("Katu", "Tonttikatu", "Asuntokatu, huoltoväylä tai muu vähäliikenteinen katu"),
+            ("Kevyt liikenne", "Piha- ja/tai kävelykatu", "Asuntokatu, huoltoväylä tai muu vähäliikenteinen katu"),
+            ("Kevyt liikenne", "Pyöräkatu", "Asuntokatu, huoltoväylä tai muu vähäliikenteinen katu"),
+            ("Jalankulku ja pyöräliikenne","Piha- ja/tai kävelykatu", "Asuntokatu, huoltoväylä tai muu vähäliikenteinen katu"),
+            ("Jalankulku ja pyöräliikenne","Pyöräkatu","Asuntokatu, huoltoväylä tai muu vähäliikenteinen katu"),
         )
 
         file_name = cfg.local_file(self._module)


### PR DESCRIPTION
### Description
Very minor change in main and sub types.
Added following pairs to street classes:
```
Katu	- Huoltotie
Muu väylä - Alueellinen kokoojakatu
```
Removed this one:
`Jalankulku ja pyöräliikenne - Pyörätie`

### Jira Issue:
https://helsinkisolutionoffice.atlassian.net/browse/HAI-3465

### Type of change

- [ ] Bug fix
- [ ] New feature
- [x] Other

### Instructions for testing
Instructions can be found from: automation/README.md:

Give following in folder /automation:
`docker build -t haitaton-gis-automation -f ./Dockerfile ..`
This wil build haitaton-gis-automation image.

Run image
Give following:
`docker run --rm --network host --env-file haitaton.env haitaton-gis-automation liikennevaylat`

Remember set all these env variables:

```
HAITATON_USER=
HAITATON_PASSWORD=
HAITATON_HOST=
HAITATON_PORT=
HAITATON_DATABASE=
HELSINKI_EXTRANET_USERNAME=
HELSINKI_EXTRANET_PASSWORD=
```
After this street classes data is written to database into the table tormays_street_classes_polys
and there should be following fields:
```
fid
street_class
silta_alikulku
geom
```